### PR TITLE
ci: skip pages actions

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -29,8 +29,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: quarto-dev/quarto-actions/setup@v2
       - uses: quarto-dev/quarto-actions/render@v2
-
-      # Only run GitHub Pages actions on 'main' branch.
       - if: github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
       - if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Skips all GitHub Pages steps since it is only needed on `main`.