### PR TITLE
docs: rethink recipe template

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -21,3 +21,4 @@ format:
   html:
     theme: cosmo
     toc: true
+    toc-expand: 3

--- a/_recipe-template.qmd
+++ b/_recipe-template.qmd
@@ -92,11 +92,9 @@ output_df <- function(ABC, new_var)
 
 :::
 
-### [Optional] Extending the recipe
+### [Optional additional subheadings, e.g. Deploy a dashboard to monitor usage]
 
 [Some recipes may have additional sections. These might have more language blocks. They might describe other related workflows, or provide supplemental material like tashboards to deploy.]
-
-[Don't use the heading "Extending the recipe"; use a descriptive heading that tells the reader what to expect when they see the heading in the sidebar, e.g. "Deploy a dashboard to monitor usage"]
 
 E.g. Here's a dashboard or something else that deploy or do.
 

--- a/_recipe-template.qmd
+++ b/_recipe-template.qmd
@@ -4,7 +4,7 @@ title: Recipe Title
 
 ## Problem
 
-[Describe what the recipe does, or set up the problem the user can solve with it, e.g. "You need to assign tags to content on your Connect server."]
+[Describe what the recipe does or set up the problem the user can solve with it, e.g., "You need to assign tags to content on your Connect server" or "You want to organize content on Connect."]
 
 ## Solution
 

--- a/_recipe-template.qmd
+++ b/_recipe-template.qmd
@@ -1,76 +1,126 @@
 ---
-title: Title
+title: Recipe Title
 ---
 
-## Description
+## Problem
 
-When would you use this recipe?
+[Describe what the recipe does, or set up the problem the user can solve with it, e.g. "You need to assign tags to content on your Connect server."]
 
-## Output
+## Solution
 
-e.g. "This recipe generates a data frame of ..." or "There is no generated output from this recipe, however it ..."
-
-## Workflow
+[If the workflow is common between Python and R, describe it outside language tabs.]
 
 This recipe requires the following inputs:
 
-1.
+1. e.g. "The unique identifier (GUID) of the content you wish to modify." Link to other recipes if they generate the inputs, e.g. generating a tag.
 
 This recipe then does the following:
 
-1.
+1. e.g. "Modifies the tags for the provided content item.
 
-## Recipe
+:::{.panel-tabset group="language"}
+
+## Python
+
+[Describe the language-specific parts of the workflow inside language tabs, e.g. "This recipe requires the identifier of the tag you wish to use"]
+
+```{.python}
+# Notes to recipe writer:
+# - Include comments where appropriate. If comments are longer than a line
+#   or two, you can break up the code block.
+# - Include the imports and client creation at the top of the workflow.
+
+from posit import connect
+
+client = connect.Client()
+
+# Note to recipe writer: if user input is required, use this format,
+# and use all-caps variable names for input the user must provide.
+
+#### User-defined inputs ####
+# 1. Specify xyz. Any clarifying text and what the default value is (if any).
+ABC = "154bd2af-e8fa-4aa4-aab8-dcef701f4af9"
+# 2. Specify abc. Any clarifying text and what the default value is (if any).
+XYZ = "23"
+#############################
+
+new_var = do_something(ABC, XYZ)
+output_df = function(ABC, new_var)
+
+```
+
+[Describe the output, e.g. "The recipe produces a data frame of outputs." When displaying outputs, display the output from an interactive session.]
+
+```{.python}
+>>> output_df
+[output printout]
+```
+
+## R
+
+```{.r}
+# Notes to recipe writer:
+# - Include comments where appropriate. If comments are longer than a line
+#   or two, you can break up the code block.
+# - Include the imports and client creation at the top of the workflow.
+
+library(connectapi)
+
+client <- connect()
+
+# Note to recipe writer: if user input is required, use this format,
+# and use all-caps variable names for input the user must provide.
+
+#### User-defined inputs ####
+# 1. Specify xyz. Any clarifying text and what the default value is (if any).
+ABC <- "154bd2af-e8fa-4aa4-aab8-dcef701f4af9"
+# 2. Specify abc. Any clarifying text and what the default value is (if any).
+XYZ <- "23"
+#############################
+
+new_var <- do_something(ABC, XYZ)
+output_df <- function(ABC, new_var)
+
+```
+
+[Describe the output, e.g. "The recipe produces a data frame of outputs." When displaying outputs, display the output from an interactive session.]
+
+```{.r}
+> output_df
+[1] "xyz"
+```
+
+:::
+
+### [Optional] Extending the recipe
+
+[Some recipes may have additional sections. These might have more language blocks. They might describe other related workflows, or provide supplemental material like tashboards to deploy.]
+
+[Don't use the heading "Extending the recipe"; use a descriptive heading that tells the reader what to expect when they see the heading in the sidebar, e.g. "Deploy a dashboard to monitor usage"]
+
+E.g. Here's a dashboard or something else that deploy or do.
 
 :::{.panel-tabset group="language"}
 
 ## Python
 
 ```{.python}
-# Note to recipe writer: Add comments. Include a requirements.txt file in this repo.
-
-# Note to recipe writer: use this for making the connection
-
-from posit import connect
-client = connect.Client()
-
-# Note to recipe writer: if user input is required, use this format:
-
-#### User-defined inputs ####
-# 1. Specify xyz. Any clarifying text and what the default value is (if any).
-xyz =
-# 2. Specify abc. Any clarifying text and what the default value is (if any).
-abc =
-###########################
-
+hello_world()
 ```
-### Example output
 
 ## R
 
 ```{.r}
-# Note to recipe writer: Add comments. Include a renv.lock file in this repo.
-
-# Note to recipe writer: use this for making the connection
-
-library(connectapi)
-client <- connect()
-
-# Note to recipe writer: if user input is required, use this format:
-
-#### User-defined inputs ####
-# 1. Specify xyz. Any clarifying text and what the default value is (if any).
-xyz <-
-# 2. Specify abc. Any clarifying text and what the default value is (if any).
-abc <-
-###########################
-
+hello_world()
 ```
-
-### Example output
 
 :::
 
-## (Optional) Extending the recipe
+## [Optional] Discussion
 
-Here's a dashboard or something else that deploy or do.
+Optionally give more detail on the subject at hand.
+
+## [Optional] See also
+
+Optionally link to other sections of the Posit Connect documentation.
+

--- a/_recipe-template.qmd
+++ b/_recipe-template.qmd
@@ -8,15 +8,11 @@ title: Recipe Title
 
 ## Solution
 
-[If the workflow is common between Python and R, describe it outside language tabs.]
+[Describe the solution in natural language. If the workflow is common between Python and R, describe it outside language tabs, but if they're significantly different, describe it in language-specific sections.
 
-This recipe requires the following inputs:
+The recipe should describe the inputs, workflow, and outputs, but doesn't need to follow a specific format for listing them out. Shorter recipes might just require a code block, and others might require more detail.]
 
-1. e.g. "The unique identifier (GUID) of the content you wish to modify." Link to other recipes if they generate the inputs, e.g. generating a tag.
-
-This recipe then does the following:
-
-1. e.g. "Modifies the tags for the provided content item.
+E.g. Assign a tag to your content. This requires obtaining the content item's unique identifier. See [Getting a content identifier](#some-other-section).
 
 :::{.panel-tabset group="language"}
 
@@ -29,20 +25,23 @@ This recipe then does the following:
 # - Include comments where appropriate. If comments are longer than a line
 #   or two, you can break up the code block.
 # - Include the imports and client creation at the top of the workflow.
+# - The recipe should ideally end with the creation of an object representing
+#   the output of the workflow, which is printed in a subsequent block.
+
 
 from posit import connect
 
-client = connect.Client()
+# Note to recipe writer: User-defined constants go in all-caps, immediately
+# after the import statements. Consider using comments to make it obvious
+# what the values are and how to get them even if the code has been copied
+# out of the recipe page.
 
-# Note to recipe writer: if user input is required, use this format,
-# and use all-caps variable names for input the user must provide.
-
-#### User-defined inputs ####
-# 1. Specify xyz. Any clarifying text and what the default value is (if any).
+# 1. Specify abc. Any clarifying text and what the default value is (if any).
 ABC = "154bd2af-e8fa-4aa4-aab8-dcef701f4af9"
-# 2. Specify abc. Any clarifying text and what the default value is (if any).
+# 2. Specify xyz. Any clarifying text and what the default value is (if any).
 XYZ = "23"
-#############################
+
+client = connect.Client()
 
 new_var = do_something(ABC, XYZ)
 output_df = function(ABC, new_var)
@@ -52,6 +51,8 @@ output_df = function(ABC, new_var)
 [Describe the output, e.g. "The recipe produces a data frame of outputs." When displaying outputs, display the output from an interactive session.]
 
 ```{.python}
+# Note to recipe writer: print the result of the recipe in a REPL/console
+# style code block.
 >>> output_df
 [output printout]
 ```
@@ -63,29 +64,32 @@ output_df = function(ABC, new_var)
 # - Include comments where appropriate. If comments are longer than a line
 #   or two, you can break up the code block.
 # - Include the imports and client creation at the top of the workflow.
+# - The recipe should ideally end with the creation of an object representing
+#   the output of the workflow, which is printed in a subsequent block.
 
 library(connectapi)
 
-client <- connect()
+# Note to recipe writer: User-defined constants go in all-caps, immediately
+# after the import statements. Consider using comments to make it obvious
+# what the values are and how to get them even if the code has been copied
+# out of the recipe page.
 
-# Note to recipe writer: if user input is required, use this format,
-# and use all-caps variable names for input the user must provide.
-
-#### User-defined inputs ####
-# 1. Specify xyz. Any clarifying text and what the default value is (if any).
+# 1. Specify abc. Any clarifying text and what the default value is (if any).
 ABC <- "154bd2af-e8fa-4aa4-aab8-dcef701f4af9"
-# 2. Specify abc. Any clarifying text and what the default value is (if any).
+# 2. Specify xyz. Any clarifying text and what the default value is (if any).
 XYZ <- "23"
-#############################
+
+client <- connect()
 
 new_var <- do_something(ABC, XYZ)
 output_df <- function(ABC, new_var)
-
 ```
 
 [Describe the output, e.g. "The recipe produces a data frame of outputs." When displaying outputs, display the output from an interactive session.]
 
 ```{.r}
+# Note to recipe writer: print the result of the recipe in a REPL/console
+# style code block.
 > output_df
 [1] "xyz"
 ```


### PR DESCRIPTION
Looking across all the recipes in the repo, almost all of them diverged from the template pretty significantly. The template was a little too prescriptive for the variety of structures that the recipes need. I adapted the lightweight format used by both the [R Cookbook](https://rc2e.com/) and [Python Cookbook](https://github.com/lpvcpp/learn_python/blob/master/D.%20Beazley%2C%20B.K.%20Jones%20-%20Python%20Cookbook%2C%203rd%20Edition.%202013.pdf) to preserve the important things that the existing template does well and address our specific needs.

- Problem: Some recipes differ between Python and R, either in required input parameters or more significantly in workflow.
  - Solution: Be more flexible about whether input and workflow descriptions happen outside or inside of language-specific tabs.
- Problem: Lack of consistency with headings. Some difficulty with flow in the template (e.g. Output described near the start, the heading "Recipe" being used to label the code snippets despite also being used to refer to the document itself).
  - Solution: Simplify headings (h2), following the conventions in the R and Python cookbooks from O'Reilly. Headings are "Problem", "Solution", Discussion [optional], See Also [optional]. Allow more flexibility with subheadings (h3...h*n*), depending on recipe requirements. Subheadings should be descriptive enough to understand what they're about from the ToC.
- Problem: Differences between example input variables.
  - Solution: Make some decisions. (1) Input variables that the user has to specify will be in all caps, other variables will be lower case. (2) We'll use actual examples of GUIDs, IDs, etc., where they are required by recipes, so that users know what shape of value they're looking for.

Here's what the new template looks like rendered:

![Screen Shot 2024-06-26 at 03 34 09 PM@2x](https://github.com/posit-dev/connect-cookbook/assets/3117884/389a1d92-7df2-46d8-ace3-837ca7766d14)
