### PR TITLE
feat: migrate runtime caches recipe

### DIFF
--- a/10-server-management/10-viewing-runtime-caches/index.qmd
+++ b/10-server-management/10-viewing-runtime-caches/index.qmd
@@ -16,7 +16,6 @@ Call Connect's API using the SDK. The API returns a JSON response that can be ea
 
 ```{.python}
 from posit import connect
-import polars as pl
 
 ABC = "154bd2af-e8fa-4aa4-aab8-dcef701f4af9"
 XYZ = "23"
@@ -30,7 +29,8 @@ caches_df = pl.DataFrame(response.json()["caches"])
 The data includes information on the language and version of the cache. For Connect servers using [off-host execution](https://docs.posit.co/connect/admin/getting-started/off-host-install/), the `image_name` column includes the name of the execution image. The name `Local` indicates that the cache is for local execution mode.
 
 ```{.python}
->>> print(caches_df)
+>>> import polars as pl
+>>> pl.DataFrame(caches_df)
 shape: (23, 3)
 ┌──────────┬─────────┬────────────┐
 │ language ┆ version ┆ image_name │
@@ -58,7 +58,6 @@ Call Connect's runtime caches API using `connectapi` and transform the response 
 ```{.r}
 library(connectapi)
 library(purrr)
-
 
 client <- connect()
 

--- a/10-server-management/10-viewing-runtime-caches/index.qmd
+++ b/10-server-management/10-viewing-runtime-caches/index.qmd
@@ -1,0 +1,90 @@
+---
+title: Viewing Runtime Caches
+---
+
+## Problem
+
+You want to enumerate a list of content runtime caches created by Connect. For more information, see the [Runtime Caches](https://docs.posit.co/connect/admin/server-management/runtime-caches/index.html) section of the Admin Guide.
+
+## Solution
+
+:::{.panel-tabset group="language"}
+
+## Python
+
+Call Connect's API using the SDK. The API returns a JSON response that can be easily transformed into a DataFrame.
+
+```{.python}
+from posit import connect
+import polars as pl
+
+ABC = "154bd2af-e8fa-4aa4-aab8-dcef701f4af9"
+XYZ = "23"
+
+client = connect.Client()
+
+response = client.get("/v1/system/caches/runtime")
+caches_df = pl.DataFrame(response.json()["caches"])
+```
+
+The data includes information on the language and version of the cache. For Connect servers using [off-host execution](https://docs.posit.co/connect/admin/getting-started/off-host-install/), the `image_name` column includes the name of the execution image. The name `Local` indicates that the cache is for local execution mode.
+
+```{.python}
+>>> print(caches_df)
+shape: (23, 3)
+┌──────────┬─────────┬────────────┐
+│ language ┆ version ┆ image_name │
+│ ---      ┆ ---     ┆ ---        │
+│ str      ┆ str     ┆ str        │
+╞══════════╪═════════╪════════════╡
+│ R        ┆ 3.0.2   ┆ Local      │
+│ R        ┆ 3.1.0   ┆ Local      │
+│ R        ┆ 3.1.2   ┆ Local      │
+│ R        ┆ 3.1.3   ┆ Local      │
+│ R        ┆ 3.2.0   ┆ Local      │
+│ …        ┆ …       ┆ …          │
+│ Python   ┆ 3.10.10 ┆ Local      │
+│ Python   ┆ 3.11.3  ┆ Local      │
+│ Python   ┆ 3.7.6   ┆ Local      │
+│ Python   ┆ 3.8.1   ┆ Local      │
+│ Python   ┆ 3.9.7   ┆ Local      │
+└──────────┴─────────┴────────────┘
+```
+
+## R
+
+Call Connect's runtime caches API using `connectapi` and transform the response into a data frame.
+
+```{.r}
+library(connectapi)
+library(purrr)
+
+
+client <- connect()
+
+response <- client$GET("/v1/system/caches/runtime")
+caches_df <- map_dfr(response$caches, ~.x)
+```
+
+The data includes information on the language and version of the cache. For Connect servers using [off-host execution](https://docs.posit.co/connect/admin/getting-started/off-host-install/), the `image_name` column includes the name of the execution image. The name `Local` indicates that the cache is for local execution mode.
+
+```{.r}
+> caches_df
+# A tibble: 23 × 3
+   language version image_name
+   <chr>    <chr>   <chr>     
+ 1 R        3.0.2   Local     
+ 2 R        3.1.0   Local     
+ 3 R        3.1.2   Local     
+ 4 R        3.1.3   Local     
+ 5 R        3.2.0   Local     
+ 6 R        3.2.1   Local     
+ 7 R        3.2.2   Local     
+ 8 R        3.3.3   Local     
+ 9 R        3.4.0   Local     
+10 R        3.4.4   Local     
+# ℹ 13 more rows
+# ℹ Use `print(n = ...)` to see more rows
+```
+
+:::

--- a/10-server-management/11-deleting-runtime-caches/index.qmd
+++ b/10-server-management/11-deleting-runtime-caches/index.qmd
@@ -1,0 +1,155 @@
+---
+title: Deleting Runtime Caches
+---
+
+## Problem
+
+You want to request the removal of a specified runtime cache.
+
+## Solution
+
+Call the `DELETE /v1/system/caches/runtime` endpoint.
+
+You must specify the language, version, and image name for the runtime cache you wish to delete. See [Viewing Runtime Caches](../10-viewing-runtime-caches/index.qmd) to view runtime caches on your Connect server.
+
+:::{.panel-tabset group="language"}
+
+## Python
+
+```{.python}
+from posit import connect
+
+LANGUAGE = "Python"
+VERSION = "3.7.6"
+IMAGE_NAME = "Local"
+
+client = connect.Client()
+
+instructions = {
+    "language": LANGUAGE,
+    "version": VERSION,
+    "image_name": IMAGE_NAME
+}
+
+response = client.delete(
+    "v1/system/caches/runtime",
+    json = instructions,
+)
+```
+
+Runtime cache deletion can take some time. A successful request indicates that deletion was started, and returns a task object. You can use this task to poll Connect's tasks API to check the status of the deletion.
+
+```{.python}
+>>> response.json()
+{'language': 'Python',
+ 'version': '3.7.6',
+ 'image_name': 'Local',
+ 'task_id': 'lFvijYN16kjCoal6'}
+```
+
+## R
+
+```{.r}
+library(connectapi)
+library(httr)
+
+LANGUAGE <- "R"
+VERSION <- "3.0.2"
+IMAGE_NAME <- "Local"
+
+client <- connect()
+
+instructions <- list(
+  language = LANGUAGE,
+  version = VERSION,
+  image_name = IMAGE_NAME
+)
+
+response <- client$DELETE(
+  "/v1/system/caches/runtime",
+  body = instructions,
+  encode = "json"
+)
+response_content <- httr::content(response, as = "parsed")
+```
+
+Runtime cache deletion can take some time. A successful request indicates that deletion was started, and returns a task object. You can use this task to poll Connect's tasks API to check the status of the deletion.
+
+```{.r}
+> response_content
+$language
+[1] "R"
+
+$version
+[1] "3.0.2"
+
+$image_name
+[1] "Local"
+
+$task_id
+[1] "uThXBHopZ2Wgv7wn"
+```
+
+:::
+
+### Polling the task
+
+Use Connect's `GET /v1/tasks/{id}` endpoint to check the status of a deletion task.
+
+:::{.panel-tabset group="language"}
+
+## Python
+
+```{.python}
+task_id = response.json()["task_id"]
+task_status = client.get(f"/v1/tasks/{task_id}")
+```
+
+```{.python}
+>>> task_status.json()
+{'id': 'lFvijYN16kjCoal6',
+ 'output': ['Deleting runtime cache...', 'Successfully deleted runtime cache'],
+ 'result': None,
+ 'finished': True,
+ 'code': 0,
+ 'error': '',
+ 'last': 2}
+```
+
+## R
+
+```{.r}
+task_id = response_content$task_id
+task_status = client$GET(glue::glue("v1/tasks/{task_id}"))
+```
+
+```{.r}
+> task_status
+$id
+[1] "uThXBHopZ2Wgv7wn"
+
+$output
+$output[[1]]
+[1] "Deleting runtime cache..."
+
+$output[[2]]
+[1] "Successfully deleted runtime cache"
+
+
+$result
+NULL
+
+$finished
+[1] TRUE
+
+$code
+[1] 0
+
+$error
+[1] ""
+
+$last
+[1] 2
+```
+
+:::

--- a/10-server-management/11-deleting-runtime-caches/index.qmd
+++ b/10-server-management/11-deleting-runtime-caches/index.qmd
@@ -33,7 +33,7 @@ instructions = {
 
 response = client.delete(
     "v1/system/caches/runtime",
-    json = instructions,
+    json=instructions,
 )
 ```
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -114,9 +114,9 @@ website:
       #   - ./09-jobs/03-viewing-job-logs/index.qmd
       #   - ./09-jobs/04-viewing-job-errors/index.qmd
       #   - ./09-jobs/05-registering-a-job-kill-order/index.qmd
-      # - section: "Server Management"
-      #   file: ./10-server-management/index.qmd
-      #   contents:
+      - section: "Server Management"
+        file: ./10-server-management/index.qmd
+        contents:
       #   - ./10-server-management/01-bootstrapping-the-server/index.qmd
       #   - ./10-server-management/02-viewing-the-server-version/index.qmd
       #   - ./10-server-management/03-viewing-runtime-users/index.qmd
@@ -126,6 +126,8 @@ website:
       #   - ./10-server-management/07-viewing-tensorflow-installations/index.qmd
       #   - ./10-server-management/08-viewing-feature-flags/index.qmd
       #   - ./10-server-management/09-analyzing-runtime-users/index.qmd
+        - ./10-server-management/10-viewing-runtime-caches/index.qmd
+        - ./10-server-management/11-deleting-runtime-caches/index.qmd
       # - section: "Off Host Execution"
       #   file: ./11-off-host-execution/index.qmd
       #   contents:


### PR DESCRIPTION
This PR migrates the runtime caches recipe.

Addresses #54 

Notes, which may require the creation of future issues
- #54 called for adding information about rebuilding content caches. However, that wasn't in the old recipe, and has not been added in this new recipe. We should add a new issue to track that.
- Neither of the SDK packages implement runtime cache deletion with task polling.
  - The original recipe includes a longer, more complex snippet to poll in a loop. I didn't add that, just a single API call to manually check. May be worthwhile preserving the old recipe's approach, but I was unsure how to present it in the format of the new notebook. The SDKs should add support for an interactive cache deletion operation that polls the tasks API to report success or failure.
  - `rsconnect-python` includes such a feature already, but I chose not to use it here.