### PR TITLE
feat: add R code to "viewing group information"

### DIFF
--- a/03-groups/01-viewing-group-information/index.qmd
+++ b/03-groups/01-viewing-group-information/index.qmd
@@ -12,13 +12,13 @@ You want to view group information.
 
 ## Python
 
-Use the `groups` attribute.
+Use the `groups` attribute. Use the `prefix` argument to filter based on group name.
 
 ```{.python}
 from posit import connect
 
 client = connect.Client()
-group = client.groups.find_one()
+group = client.groups.find_one(prefix="data scientists")
 ```
 
 ```{.python}
@@ -33,9 +33,24 @@ group = client.groups.find_one()
 
 ## R
 
+Use the `get_groups()` function. This returns a table that you can filter to find details about a specific group.
 
 ```{.r}
-# TODO
+library(connectapi)
+library(dplyr)
+
+client <- connect()
+
+all_groups <- get_groups(client)
+group <- filter(groups, name == "Data Scientists")
+```
+
+```{.r}
+> group
+# A tibble: 1 × 3
+  guid                                 name            owner_guid                          
+  <chr>                                <chr>           <chr>                               
+1 54ed1e9d-4bee-4797-97a3-f22e990bccfe Data Scientists 6ca57cef-186f-4897-9875-d692f97edd5a
 ```
 
 :::

--- a/03-groups/01-viewing-group-information/index.qmd
+++ b/03-groups/01-viewing-group-information/index.qmd
@@ -17,8 +17,10 @@ Use the `groups` attribute. Use the `prefix` argument to filter based on group n
 ```{.python}
 from posit import connect
 
+PREFIX = "data scientists"
+
 client = connect.Client()
-group = client.groups.find_one(prefix="data scientists")
+group = client.groups.find_one(prefix=PREFIX)
 ```
 
 ```{.python}
@@ -39,10 +41,12 @@ Use the `get_groups()` function. This returns a table that you can filter to fin
 library(connectapi)
 library(dplyr)
 
+GROUP_NAME = "Data Scientists"
+
 client <- connect()
 
 all_groups <- get_groups(client)
-group <- filter(groups, name == "Data Scientists")
+group <- filter(groups, name == GROUP_NAME)
 ```
 
 ```{.r}

--- a/03-groups/02-finding-groups/index.qmd
+++ b/03-groups/02-finding-groups/index.qmd
@@ -4,7 +4,7 @@ title: Finding Groups
 
 ## Problem
 
-You want to find a subset of groups.
+You want to find a subset of the groups on the Connect server.
 
 ## Solution
 
@@ -39,8 +39,25 @@ shape: (2, 3)
 
 ## R
 
+Use the `get_groups()` function. This returns a data frame of all groups on the Connect server. You can filter this as you would any other table.
+
 ```{.r}
-# TODO
+library(connectapi)
+library(dplyr)
+
+client <- connect()
+
+all_groups <- get_groups(client)
+```
+
+```{.r}
+> all_groups
+# A tibble: 2 × 3
+   guid                                 name            owner_guid                          
+   <chr>                                <chr>           <chr>                               
+ 1 c6beca6e-0898-4c27-b295-8beec58735d7 Data Scientists 4d81b29b-a2b2-41d3-8ef5-32cc5f63e679
+ 2 8071ec0e-9be2-4c26-a829-4f60a21ccb94 Data Engineers  4b03b981-0cfc-4d51-8dd4-a5521fe6dfb0
+
 ```
 
 :::

--- a/14-mlops/03-promoting-content-from-staging-to-production/index.qmd
+++ b/14-mlops/03-promoting-content-from-staging-to-production/index.qmd
@@ -99,9 +99,11 @@ deployment_task.wait_for()
 assert deployment_task.exit_code == 0
 ```
 
+<!--
 ## R
 
-TODO
+TODO 
+-->
 
 :::
 


### PR DESCRIPTION
- Added R code to viewing group information.
- I also added information about the Python `prefix` argument to that recipe, because just telling users how to view information on the first group that `find_one()` returns seems very unhelpful.
- The "Finding Groups" recipe also receives R code. This recipe is almost identical to the "Viewing Group Information" recipe (because finding groups inherently involves viewing information on them). We should probably de-duplicate these at some point.
- Commented out R `TODO` on the "Promoting Content" recipe for now.