### PR TITLE
use same case for username

### DIFF
--- a/content/finding-content-owned-by-a-user/index.qmd
+++ b/content/finding-content-owned-by-a-user/index.qmd
@@ -21,7 +21,7 @@ Using the SDK to look up a user, you can directly access that user's owned conte
 ```{.python}
 from posit import connect
 
-USERNAME = "publisher1"
+username = "publisher1"
 
 client = connect.Client()
 
@@ -49,7 +49,7 @@ Look up the user's unique identifier (GUID), and use that to find all their owne
 ```{.r}
 library(connectapi)
 
-USERNAME <- "publisher1"
+username <- "publisher1"
 
 client <- connect()
 

--- a/content/finding-content-owned-by-a-user/index.qmd
+++ b/content/finding-content-owned-by-a-user/index.qmd
@@ -21,11 +21,11 @@ Using the SDK to look up a user, you can directly access that user's owned conte
 ```{.python}
 from posit import connect
 
-username = "publisher1"
+USERNAME = "publisher1"
 
 client = connect.Client()
 
-content = client.users.find_one(prefix = username).content.find()
+content = client.users.find_one(prefix = USERNAME).content.find()
 ```
 
 The recipe produces a DataFrame containing all of the user's owned content.
@@ -49,11 +49,11 @@ Look up the user's unique identifier (GUID), and use that to find all their owne
 ```{.r}
 library(connectapi)
 
-username <- "publisher1"
+USERNAME <- "publisher1"
 
 client <- connect()
 
-user_guid <- user_guid_from_username(client, username)
+user_guid <- user_guid_from_username(client, USERNAME)
 content <- get_content(client, owner_guid = user_guid)
 ```
 


### PR DESCRIPTION
this recipe fails on macOS when `username` isn't a consistent case.