### PR TITLE
feat: add note about connectapi verison requirement to restart and render

### DIFF
--- a/content/rendering-content/index.qmd
+++ b/content/rendering-content/index.qmd
@@ -43,6 +43,12 @@ if content.is_rendered:
 
 ## R
 
+:::{.callout-note}
+
+This functionality requires `connectapi` version 0.3.0.
+
+:::
+
 Invoke the `content_render` function to render content.
 
 ```r

--- a/content/restarting-content/index.qmd
+++ b/content/restarting-content/index.qmd
@@ -35,6 +35,12 @@ if content.is_interactive:
 
 ## R
 
+:::{.callout-note}
+
+This functionality requires `connectapi` version 0.3.0.
+
+:::
+
 Invoke the `content_restart` function to trigger a content restart.
 
 ```r


### PR DESCRIPTION
`content_restart()` and `content_render()` will require `connectapi` 0.3.0. This release won't come out till mid-August due to the CRAN vacation, so this PR adds a short note about the version requirement to those recipes under the R tab.