### PR TITLE
feat: example using `targets` in a render pipeline

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -161,6 +161,7 @@ website:
         # - ./operations/rendering-content-on-demand/index.qmd
         - ./operations/promoting-content-from-staging-to-production/index.qmd
         - ./operations/blue-green-deployments/index.qmd
+        - ./operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
 
 format:
   html:

--- a/content/rendering-content/index.qmd
+++ b/content/rendering-content/index.qmd
@@ -44,9 +44,7 @@ if content.is_rendered:
 ## R
 
 :::{.callout-note}
-
-This functionality requires `connectapi` version 0.3.0.
-
+This functionality requires `connectapi` version 0.3.0 or later.
 :::
 
 Invoke the `content_render` function to render content.

--- a/content/restarting-content/index.qmd
+++ b/content/restarting-content/index.qmd
@@ -36,9 +36,7 @@ if content.is_interactive:
 ## R
 
 :::{.callout-note}
-
-This functionality requires `connectapi` version 0.3.0.
-
+This functionality requires `connectapi` version 0.3.0 or later.
 :::
 
 Invoke the `content_restart` function to trigger a content restart.

--- a/operations/index.qmd
+++ b/operations/index.qmd
@@ -7,4 +7,5 @@ listing:
     - ./deploying-content
     - ./promoting-content-from-staging-to-production
     - ./blue-green-deployments
+    - ./rendering-and-restarting-content-from-r-data-science-pipelines-with-targets
 ---

--- a/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
+++ b/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
@@ -13,7 +13,7 @@ You use the [`targets`](https://books.ropensci.org/targets/) R package to manage
 ## Solution
 
 :::{.callout-note}
-This functionality requires `connectapi` version 0.3.0.
+This functionality requires `connectapi` version 0.3.0 or later.
 :::
 
 Define a `targets` function that uses `connectapi` to render or restart your content. This example loads a data frame, performs a simple manipulation, and publishes the result to a pin using the [`pins` package](https://pins.rstudio.com/).

--- a/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
+++ b/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: Rendering and Restarting Content from R Data Science Pipelines with `targets`
+title: Workflow Automation in R using `targets`
 ---
 
 :::{.callout-note}

--- a/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
+++ b/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
@@ -27,7 +27,9 @@ This is the file layout in our `targets` project.
 │   ├── functions.R
 ```
 
-The `load_data()` function reads the data, performs a bootstrap sample operation, and returns a data frame. The `publish_data()` function takes the resulting data frame, publishes it to a pin stored on Connect, and returns a data frame of the pin versions. The functions `remote_render()` and `remote_restart()` call `content_render()` and `content_restart()` respectively, to render or restart pieces of Connect content that load the pin data directly. They depend on the pin version data from `publish_data()`, even though that object is not used directly in the function body, which causes them to run whenever the pin has been updated.
+The `load_data()` function reads the data, performs a bootstrap sample operation, and returns a data frame. The `publish_data()` function takes the resulting data frame, publishes it to a pin stored on Connect, and returns a data frame of pin versions. 
+
+The functions `remote_render()` and `remote_restart()` call `content_render()` and `content_restart()` respectively, to render or restart pieces of Connect content that load the pin data directly. These functions have an argument which is not used directly in the function body, but is used to tell `targets` to when to run them.
 
 ```{.r}
 # R/functions.R
@@ -64,7 +66,7 @@ remote_restart <- function(pin_versions) {
 }
 ```
 
-The functions are used in the pipeline file `_targets.R` like this.
+We use these functions in the file `_targets.R` to define our pipeline. The output of `publish_data()` — the data frame of pin version data — is passed to `remote_render()` and `remote_refresh()`. The version data changes whenever the pin is updated, which causes `targets` to run all the functions that depend on it, refreshing the content on Connect as needed.
 
 ```{.r}
 # _targets.R
@@ -85,7 +87,7 @@ list(
 )
 ```
 
-The output of `publish_data()` is used as the dependency for each of the functions that updates the content on Connect.
+This `targets` pipeline thus allows us to automate content render and restart tasks on Connect from an external data science pipeline.
 
 ## Discussion
 

--- a/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
+++ b/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
@@ -8,7 +8,7 @@ This recipe assumes familiarity with the `targets` R package. See the `targets` 
 
 ## Problem
 
-You use the [`targets`](https://books.ropensci.org/targets/) R package to manage a data science pipeline. You have content published to Connect that uses artifacts created by the pipeline and want to programmatically trigger the content to render or restart after certain stages of the pipeline have finished.
+You use the [`targets`](https://books.ropensci.org/targets/) R package to manage a data science pipeline. You have content published to Connect that uses artifacts created by the pipeline, and want to programmatically trigger the content to render or restart after certain stages of the pipeline have finished.
 
 ## Solution
 

--- a/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
+++ b/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
@@ -95,4 +95,5 @@ In this example, the output of `pin_versions()` changes when a new version of th
 
 ## See also
 
-- For details on rendering and restarting content, see [Rendering Content](../../content/rendering-content/index.qmd) and [Restarting Content](../../content/restarting-content/index.qmd).
+- [Rendering Content](../../content/rendering-content/index.qmd)
+- [Restarting Content](../../content/restarting-content/index.qmd)

--- a/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
+++ b/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
@@ -27,7 +27,7 @@ This is the file layout in our `targets` project.
 │   ├── functions.R
 ```
 
-The `load_data()` function reads the data, performs a bootstrap sample operation, and returns a data frame. The `publish_data()` function takes the resulting data frame, publishes it to a pin stored on Connect, and returns a data frame of the pin versions. The functions `remote_render()` and `remote_restart()` call `content_render()` and `content_restart()` respectively, to render or restart pieces of Connect content that load the pin data directly. They depend on the pin version data from `publish_data()` even though that object is not used directly in the function body, which causes them to run whenever the pin has been updated.
+The `load_data()` function reads the data, performs a bootstrap sample operation, and returns a data frame. The `publish_data()` function takes the resulting data frame, publishes it to a pin stored on Connect, and returns a data frame of the pin versions. The functions `remote_render()` and `remote_restart()` call `content_render()` and `content_restart()` respectively, to render or restart pieces of Connect content that load the pin data directly. They depend on the pin version data from `publish_data()`, even though that object is not used directly in the function body, which causes them to run whenever the pin has been updated.
 
 ```{.r}
 # R/functions.R

--- a/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
+++ b/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
@@ -29,7 +29,7 @@ This is the file layout in our `targets` project.
 
 The `load_data()` function reads the data, performs a bootstrap sample operation, and returns a data frame. The `publish_data()` function takes the resulting data frame, publishes it to a pin stored on Connect, and returns a data frame of pin versions. 
 
-The functions `remote_render()` and `remote_restart()` call `content_render()` and `content_restart()` respectively, to render or restart pieces of Connect content that load the pin data directly. These functions have an argument which is not used directly in the function body, but is used to tell `targets` to when to run them.
+The functions `remote_render()` and `remote_restart()` call `content_render()` and `content_restart()` respectively, to render or restart pieces of Connect content that load the pin data directly. These functions have an argument which is not used directly in the function body, but is used to tell `targets` when to run them.
 
 ```{.r}
 # R/functions.R

--- a/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
+++ b/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
@@ -1,0 +1,98 @@
+---
+title: Rendering and Restarting Content from R Data Science Pipelines with `targets`
+---
+
+:::{.callout-note}
+This recipe assumes familiarity with the `targets` R package. See the `targets` [user manual](https://books.ropensci.org/targets/) for documentation. This recipe does not contain Python examples.
+:::
+
+## Problem
+
+You use the [`targets`](https://books.ropensci.org/targets/) R package to manage a data science pipeline. You have content published to Connect that uses artifacts created by the pipeline and want to programmatically trigger the content to render or restart after certain stages of the pipeline have finished.
+
+## Solution
+
+:::{.callout-note}
+This functionality requires `connectapi` version 0.3.0.
+:::
+
+Define a `targets` function that uses `connectapi` to render or restart your content. This example loads a data frame, performs a simple manipulation, and publishes the result to a pin using the [`pins` package](https://pins.rstudio.com/).
+
+This is the file layout in our `targets` project.
+
+```{.default}
+├── _targets.R
+├── penguins.csv
+├── R/
+│   ├── functions.R
+```
+
+The `load_data()` function reads the data, performs a bootstrap sample operation, and returns a data frame. The `publish_data()` function takes the resulting data frame, publishes it to a pin stored on Connect, and returns a data frame of the pin versions. The functions `remote_render()` and `remote_restart()` call `content_render()` and `content_restart()` respectively, to render or restart pieces of Connect content that load the pin data directly. They depend on the pin version data from `publish_data()` even though that object is not used directly in the function body, which causes them to run whenever the pin has been updated.
+
+```{.r}
+# R/functions.R
+load_data <- function(file) {
+  read_csv(file) %>%
+    # In this example, changing the sample size causes the rest of the
+    # pipeline to rerun.
+    sample_n(size = 300, replace = TRUE)
+}
+
+publish_data <- function(penguins_df) {
+  board <- board_connect(auth = "envvar")
+  board %>% pin_write(penguins_df, "toph/penguins")
+
+  # Return the version of the pin. This changes whenever the pin is updated.
+  board %>% pin_versions("toph/penguins")
+}
+
+remote_render <- function(pin_versions) {
+  # Including the pin_versions as a dependency causes the render function to be
+  # called whenever the pin has been updated.
+  client <- connect()
+  content_item(client, "2ab81f20-bbb5-4b6f-bbc6-2014ddb2cb80") %>%
+    content_render() %>%
+    poll_task()
+}
+
+remote_restart <- function(pin_versions) {
+  # Including the pin_versions as a dependency causes the restart function to be
+  # called whenever the pin has been updated.
+  client <- connect()
+  content_item(client, "d656f5df-8897-4878-8802-4cf74d0c078d") %>%
+    content_restart()
+}
+```
+
+The functions are used in the pipeline file `_targets.R` like this.
+
+```{.r}
+# _targets.R
+library(targets)
+
+tar_option_set(
+  packages = c("readr", "tibble", "connectapi", "pins", "dplyr")
+)
+
+tar_source("R/functions.R")
+
+list(
+  tar_target(penguins_file, "penguins.csv", format = "file"),
+  tar_target(penguins_df, load_data(penguins_file)),
+  tar_target(pin_versions, publish_data(penguins_df)),
+  tar_target(render_result, remote_render(pin_versions)),
+  tar_target(restart_result, remote_refresh(pin_versions))
+)
+```
+
+The output of `publish_data()` is used as the dependency for each of the functions that updates the content on Connect.
+
+## Discussion
+
+This example uses `pins`, but that isn't a requirement to trigger content renders and restarts on Connect from `targets`. Any data source that you publish to from R and load from a Connect content item can be used similarly, as long as your `targets` function returns an artifact whose hash changes whenever the content needs to be rendered or restarted.
+
+In this example, the output of `pin_versions()` changes when a new version of the dataset is published. This is returned from our `publish_data()` function, and is passed in as a dependency to our `remote_render()` and `remote_refresh()` functions, causing them to run whenever a new pin is published.
+
+## See also
+
+- For details on rendering and restarting content, see [Rendering Content](../../content/rendering-content/index.qmd) and [Restarting Content](../../content/restarting-content/index.qmd).

--- a/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
+++ b/operations/rendering-and-restarting-content-from-r-data-science-pipelines-with-targets/index.qmd
@@ -89,7 +89,7 @@ The output of `publish_data()` is used as the dependency for each of the functio
 
 ## Discussion
 
-This example uses `pins`, but that isn't a requirement to trigger content renders and restarts on Connect from `targets`. Any data source that you publish to from R and load from a Connect content item can be used similarly, as long as your `targets` function returns an artifact whose hash changes whenever the content needs to be rendered or restarted.
+This example uses `pins`, but that isn't a requirement to trigger content renders and restarts on Connect from `targets`. As long as your `targets` function returns an artifact whose hash changes whenever the content needs to be rendered or restarted, any data source that you publish to from R and load from a Connect content item can be used similarly.
 
 In this example, the output of `pin_versions()` changes when a new version of the dataset is published. This is returned from our `publish_data()` function, and is passed in as a dependency to our `remote_render()` and `remote_refresh()` functions, causing them to run whenever a new pin is published.
 


### PR DESCRIPTION
This PR adds an R example to the Operations section which demonstrates how to use `connectapi` functions in a `targets` pipeline to render and restart content in response to a change in the pipeline's artifacts. The example uses `pins` for data storage, but explains how to use other data storage frameworks.

Using the code style `targets` in the title renders correctly in the actual document title and the sidebar, but not in the listing on the Operations page. Still, I think it's fine — most people reading this will know what the backticks mean.

Copy edits encouraged!

![Screen Shot 2024-08-06 at 02 21 51 PM@2x](https://github.com/user-attachments/assets/cc97e681-a14b-4b2a-a862-2ddb549c9942)
